### PR TITLE
Add `disabled` property to the `toggleConfig` type

### DIFF
--- a/projects/ng-toggle/src/lib/ng-toggle.component.ts
+++ b/projects/ng-toggle/src/lib/ng-toggle.component.ts
@@ -219,7 +219,7 @@ export const translate = (x, y) => {
 export type toggleConfig = {
   checked: string;
   unchecked: string;
-  disabled: string;
+  disabled?: string;
 };
 
 export type valueConfig = {

--- a/projects/ng-toggle/src/lib/ng-toggle.component.ts
+++ b/projects/ng-toggle/src/lib/ng-toggle.component.ts
@@ -219,6 +219,7 @@ export const translate = (x, y) => {
 export type toggleConfig = {
   checked: string;
   unchecked: string;
+  disabled: string;
 };
 
 export type valueConfig = {


### PR DESCRIPTION
The documentation says that you can pass in an object to the `color` input prop that has a `disabled` property yet the current type doesn't allow for that. This change makes it possible to do just that without getting a type error